### PR TITLE
fix/Loading Scene - Bug

### DIFF
--- a/src/Core/GameLoop.cpp
+++ b/src/Core/GameLoop.cpp
@@ -59,8 +59,10 @@ void GameLoop::update() {
     }
 
     // Update scene
-    if(GolfEngine::SceneManager::GetSceneManager().hasCurrentScene()){
-        auto& currentScene = GolfEngine::SceneManager::GetSceneManager().getCurrentScene();
+    auto& sceneManager = GolfEngine::SceneManager::GetSceneManager();
+    sceneManager.updateSceneManager();
+    if(sceneManager.hasCurrentScene()){
+        auto& currentScene = sceneManager.getCurrentScene();
         currentScene.updateReplay();
         currentScene.updateScene();
     }

--- a/src/Core/SceneManager.cpp
+++ b/src/Core/SceneManager.cpp
@@ -17,19 +17,7 @@ namespace GolfEngine {
     }
 
     void SceneManager::loadScene(const std::string& sceneName) {
-        std::_Rb_tree_iterator<std::pair<const std::basic_string<char>, std::unique_ptr<ISceneFactory>>> sceneFactory;
-        // If empty string is passed, reload last loaded scene
-        if(sceneName.empty())
-            sceneFactory = _scenes.find(_lastScene);
-        else
-            sceneFactory = _scenes.find(sceneName);
-
-        if (sceneFactory != _scenes.end()){
-            _lastScene = sceneName;
-            _currentScene = std::make_unique<Scene>();
-            sceneFactory->second->build(*_currentScene);
-            _currentScene->startScene();
-        }
+        _nextScene = sceneName;
     }
 
     Scene& SceneManager::getCurrentScene() {
@@ -42,5 +30,28 @@ namespace GolfEngine {
 
     void SceneManager::clearScenes() {
         _scenes.erase(_scenes.begin(), _scenes.end());
+    }
+
+    void SceneManager::updateSceneManager() {
+        //Check if the current scene should be changed
+        if(_nextScene){
+            const auto& sceneName = _nextScene.value();
+            std::_Rb_tree_iterator<std::pair<const std::basic_string<char>, std::unique_ptr<ISceneFactory>>> sceneFactory;
+            // If empty string is passed, reload last loaded scene
+            if(sceneName.empty())
+                sceneFactory = _scenes.find(_lastScene);
+            else
+                sceneFactory = _scenes.find(sceneName);
+
+            if (sceneFactory != _scenes.end()){
+                _lastScene = sceneName;
+                _currentScene = std::make_unique<Scene>();
+                sceneFactory->second->build(*_currentScene);
+                _currentScene->startScene();
+            }
+
+            _nextScene.reset();
+        }
+
     }
 }

--- a/src/Core/SceneManager.h
+++ b/src/Core/SceneManager.h
@@ -6,8 +6,10 @@
 #define SPC_PROJECT_SCENEMANAGER_H
 
 #include <map>
-#include "../Scene/Scene.h"
 #include <memory>
+#include <optional>
+
+#include "../Scene/Scene.h"
 #include "../Scene/ISceneFactory.h"
 
 class ISceneFactory;
@@ -20,6 +22,9 @@ private:
     std::unique_ptr<Scene> _currentScene;
     std::string _lastScene;
 
+    // If this has a value, then the next call to updateSceneManager() will change the scene to the string given
+    std::optional<std::string> _nextScene {};
+
     static std::unique_ptr<SceneManager> sceneManager;
 
     SceneManager();
@@ -28,7 +33,8 @@ public:
     /// \return Returns the global scene manager instance
     static SceneManager& GetSceneManager();
 
-    /// Loads new scene by setting the currentScene of a copy of the loaded scene
+    /// A deferred call to load  a new scene by setting the currentScene of a copy of the loaded scene
+    /// The actual loading happens on the next updateSceneManager() call
     /// \param sceneName Name of scene to load, if empty, current scene will be reloaded
     void loadScene(const std::string &sceneName = "");
 
@@ -39,6 +45,10 @@ public:
     void addSceneFactory(const std::string& sceneName){
         _scenes.insert(std::make_pair(sceneName, std::make_unique<SF>()));
     }
+
+    /// Update the scene manager if needed, should be called by the GameLoop before updating the current scene.
+    /// For now the only update action is loading in a new scene if _nextScene has a value
+    void updateSceneManager();
 
     /// Returns reference to _currentScene
     /// \return


### PR DESCRIPTION
De scene loading wordt deffered naar `SceneManager::updateSceneManager()`

Nu wordt er in de GameLoop voor het updaten van de scene de `SceneManager::updateSceneManager()` methode aangeroepen.